### PR TITLE
Added remaining migrations

### DIFF
--- a/HotelService/src/db/migrations/20250422161418-add-deleted-at-to-hotels.ts
+++ b/HotelService/src/db/migrations/20250422161418-add-deleted-at-to-hotels.ts
@@ -1,7 +1,7 @@
-import { DataTypes, QueryInterface } from "sequelize";
+import { DataTypes, QueryInterface } from 'sequelize';
 
 module.exports = {
-  async up (queryInterface: QueryInterface) {
+  async up(queryInterface: QueryInterface) {
     await queryInterface.addColumn('hotels', 'deleted_at', {
       type: DataTypes.DATE,
       allowNull: true,
@@ -9,7 +9,7 @@ module.exports = {
     });
   },
 
-  async down (queryInterface: QueryInterface) {
+  async down(queryInterface: QueryInterface) {
     await queryInterface.removeColumn('hotels', 'deleted_at');
-  }
+  },
 };

--- a/HotelService/src/db/migrations/20250603055920-create-room-table.ts
+++ b/HotelService/src/db/migrations/20250603055920-create-room-table.ts
@@ -1,0 +1,23 @@
+import { QueryInterface } from 'sequelize';
+
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS rooms (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      room_category_id INT,
+      hotel_id INT,
+      room_no INT NOT NULL,
+      date_of_availability DATE NOT NULL,
+      booking_id INT,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      deleted_at TIMESTAMP DEFAULT NULL)`);
+  },
+
+  async down(queryInterface: QueryInterface) {
+    await queryInterface.sequelize.query(`
+      DROP TABLE IF EXISTS rooms;
+      `);
+  },
+};

--- a/HotelService/src/db/migrations/20250603070348-create-room-category-table.ts
+++ b/HotelService/src/db/migrations/20250603070348-create-room-category-table.ts
@@ -1,0 +1,22 @@
+import { QueryInterface } from 'sequelize';
+
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    await queryInterface.sequelize.query(`
+      CREATE TABLE IF NOT EXISTS room_categories (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      room_type ENUM('SINGLE', 'DOUBLE', 'FAMILY', 'DELUXE', 'SUITE') NOT NULL,
+      price INT NOT NULL,
+      hotel_id INT,
+      room_count INT NOT NULL,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+      deleted_at TIMESTAMP DEFAULT NULL)`);
+  },
+
+  async down(queryInterface: QueryInterface) {
+    await queryInterface.sequelize.query(`
+      DROP TABLE IF EXISTS room_categories;
+      `);
+  },
+};

--- a/HotelService/src/db/migrations/20250603071816-add-room-category-association.ts
+++ b/HotelService/src/db/migrations/20250603071816-add-room-category-association.ts
@@ -1,0 +1,23 @@
+import { QueryInterface } from 'sequelize';
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    await queryInterface.addConstraint('rooms', {
+      type: 'foreign key',
+      name: 'room_categories_fkey_constraint',
+      fields: ['room_category_id'],
+      references: {
+        table: 'room_categories',
+        field: 'id',
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    });
+  },
+
+  async down(queryInterface: QueryInterface) {
+    await queryInterface.removeConstraint(
+      'rooms',
+      'room_categories_fkey_constraint'
+    );
+  },
+};

--- a/HotelService/src/db/migrations/20250603072058-add-room-category-hotel-association.ts
+++ b/HotelService/src/db/migrations/20250603072058-add-room-category-hotel-association.ts
@@ -1,0 +1,23 @@
+import { QueryInterface } from 'sequelize';
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    await queryInterface.addConstraint('room_categories', {
+      type: 'foreign key',
+      name: 'room_categories_hotel_fkey_constraint',
+      fields: ['hotel_id'],
+      references: {
+        table: 'hotels',
+        field: 'id',
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    });
+  },
+
+  async down(queryInterface: QueryInterface) {
+    await queryInterface.removeConstraint(
+      'room_categories',
+      'room_categories_hotel_fkey_constraint'
+    );
+  },
+};

--- a/HotelService/src/db/migrations/20250603072103-add-hotel-room-association.ts
+++ b/HotelService/src/db/migrations/20250603072103-add-hotel-room-association.ts
@@ -1,0 +1,20 @@
+import { QueryInterface } from 'sequelize';
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    await queryInterface.addConstraint('rooms', {
+      type: 'foreign key',
+      name: 'room_fkey_constraint',
+      fields: ['hotel_id'],
+      references: {
+        table: 'hotels',
+        field: 'id',
+      },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
+    });
+  },
+
+  async down(queryInterface: QueryInterface) {
+    await queryInterface.removeConstraint('rooms', 'room_fkey_constraint');
+  },
+};

--- a/HotelService/src/db/models/hotel.ts
+++ b/HotelService/src/db/models/hotel.ts
@@ -1,61 +1,72 @@
-import { CreationOptional, InferAttributes, InferCreationAttributes, Model } from "sequelize";
-import sequelize from "./sequelize";
+import {
+  CreationOptional,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+} from 'sequelize';
+import sequelize from './sequelize';
 
-class Hotel extends Model<InferAttributes<Hotel>, InferCreationAttributes<Hotel> > {
-    declare id: CreationOptional<number>;
-    declare name: string;
-    declare address: string;
-    declare location: string;
-    declare createdAt: CreationOptional<Date>;
-    declare updatedAt: CreationOptional<Date>;
-    declare deletedAt: CreationOptional<Date | null>;
-    declare rating?: number;
-    declare ratingCount?: number;
+class Hotel extends Model<
+  InferAttributes<Hotel>,
+  InferCreationAttributes<Hotel>
+> {
+  declare id: CreationOptional<number>;
+  declare name: string;
+  declare address: string;
+  declare location: string;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare deletedAt: CreationOptional<Date | null>;
+  declare rating?: number;
+  declare ratingCount?: number;
 }
 
-Hotel.init({
+Hotel.init(
+  {
     id: {
-        type: "INTEGER",
-        autoIncrement: true,
-        primaryKey: true,
+      type: 'INTEGER',
+      autoIncrement: true,
+      primaryKey: true,
     },
     name: {
-        type: "STRING",
-        allowNull: false,
+      type: 'STRING',
+      allowNull: false,
     },
     address: {
-        type: "STRING",
-        allowNull: false,
+      type: 'STRING',
+      allowNull: false,
     },
     location: {
-        type: "STRING",
-        allowNull: false,
+      type: 'STRING',
+      allowNull: false,
     },
     createdAt: {
-        type: "DATE",
-        defaultValue: new Date(),
+      type: 'DATE',
+      defaultValue: new Date(),
     },
     updatedAt: {
-        type: "DATE",
-        defaultValue: new Date(),
+      type: 'DATE',
+      defaultValue: new Date(),
     },
     deletedAt: {
-        type: "DATE",
-        defaultValue: null,
+      type: 'DATE',
+      defaultValue: null,
     },
     rating: {
-        type: "FLOAT",
-        defaultValue: null,
+      type: 'FLOAT',
+      defaultValue: null,
     },
     ratingCount: {
-        type: "INTEGER",
-        defaultValue: null,
-    }
-}, {
-    tableName: "hotels",
+      type: 'INTEGER',
+      defaultValue: null,
+    },
+  },
+  {
+    tableName: 'hotels',
     sequelize: sequelize,
     underscored: true, // createdAt --> created_at
     timestamps: true, // createdAt, updatedAt
-});
+  }
+);
 
 export default Hotel;

--- a/HotelService/src/db/models/room.ts
+++ b/HotelService/src/db/models/room.ts
@@ -1,0 +1,79 @@
+import {
+  CreationOptional,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+} from 'sequelize';
+import sequelize from './sequelize';
+import Hotel from './hotel';
+import RoomCategory from './roomCategory';
+
+class Room extends Model<InferAttributes<Room>, InferCreationAttributes<Room>> {
+  declare id: CreationOptional<number>;
+  declare hotelId: number;
+  declare roomCategoryId: number;
+  declare dateOfAvailability: Date;
+  declare price: number;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare deletedAt: CreationOptional<Date> | null;
+  declare bookingId?: number | null;
+}
+
+Room.init(
+  {
+    id: {
+      type: 'INTEGER',
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    hotelId: {
+      type: 'INTEGER',
+      allowNull: false,
+      references: {
+        model: Hotel,
+        key: 'id',
+      },
+    },
+    roomCategoryId: {
+      type: 'INTEGER',
+      allowNull: false,
+      references: {
+        model: RoomCategory,
+        key: 'id',
+      },
+    },
+    dateOfAvailability: {
+      type: 'DATE',
+      allowNull: false,
+    },
+    price: {
+      type: 'INTEGER',
+      allowNull: false,
+    },
+    createdAt: {
+      type: 'DATE',
+      defaultValue: new Date(),
+    },
+    updatedAt: {
+      type: 'DATE',
+      defaultValue: new Date(),
+    },
+    deletedAt: {
+      type: 'DATE',
+      defaultValue: null,
+    },
+    bookingId: {
+      type: 'INTEGER',
+      defaultValue: null,
+    },
+  },
+  {
+    tableName: 'rooms',
+    sequelize: sequelize,
+    underscored: true,
+    timestamps: true,
+  }
+);
+
+export default Room;

--- a/HotelService/src/db/models/roomCategory.ts
+++ b/HotelService/src/db/models/roomCategory.ts
@@ -1,0 +1,80 @@
+import {
+  CreationOptional,
+  InferAttributes,
+  InferCreationAttributes,
+  Model,
+} from 'sequelize';
+import sequelize from './sequelize';
+import Hotel from './hotel';
+
+enum RoomType {
+  SINGLE = 'SINGLE',
+  DOUBLE = 'DOUBLE',
+  FAMILY = 'FAMILY',
+  DELUXE = 'DELUXE',
+  SUITE = 'SUITE',
+}
+
+class RoomCategory extends Model<
+  InferAttributes<RoomCategory>,
+  InferCreationAttributes<RoomCategory>
+> {
+  declare id: CreationOptional<number>;
+  declare hotelId: number;
+  declare price: number;
+  declare roomType: RoomType;
+  declare roomCount: number;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+  declare deletedAt: CreationOptional<Date> | null;
+}
+
+RoomCategory.init(
+  {
+    id: {
+      type: 'INTEGER',
+      autoIncrement: true,
+      primaryKey: true,
+    },
+    hotelId: {
+      type: 'INTEGER',
+      allowNull: false,
+      references: {
+        model: Hotel,
+        key: 'id',
+      },
+    },
+    price: {
+      type: 'INTEGER',
+      allowNull: false,
+    },
+    roomType: {
+      type: 'ENUM',
+      values: [...Object.values(RoomType)],
+    },
+    roomCount: {
+      type: 'INTEGER',
+      allowNull: false,
+    },
+    createdAt: {
+      type: 'DATE',
+      defaultValue: new Date(),
+    },
+    updatedAt: {
+      type: 'DATE',
+      defaultValue: new Date(),
+    },
+    deletedAt: {
+      type: 'DATE',
+      defaultValue: null,
+    },
+  },
+  {
+    tableName: 'room_categories',
+    sequelize: sequelize,
+    underscored: true,
+    timestamps: true,
+  }
+);
+
+export default RoomCategory;

--- a/HotelService/src/db/seeders/20250603065141-seed-hotels-rooms-data.ts
+++ b/HotelService/src/db/seeders/20250603065141-seed-hotels-rooms-data.ts
@@ -1,0 +1,140 @@
+import { QueryInterface } from 'sequelize';
+
+module.exports = {
+  async up(queryInterface: QueryInterface) {
+    await queryInterface.bulkInsert('hotels', [
+      {
+        id: 1,
+        name: 'Ocean View Hotel',
+        address: '123 Beachside Lane',
+        location: 'Goa',
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      },
+      {
+        id: 2,
+        name: 'Mountain Retreat',
+        address: '456 Hilltop Road',
+        location: 'Manali',
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      },
+    ]);
+
+    await queryInterface.bulkInsert('room_categories', [
+      {
+        hotel_id: 1,
+        price: 3000,
+        room_type: 'SINGLE',
+        room_count: 10,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      },
+      {
+        hotel_id: 1,
+        price: 5000,
+        room_type: 'DOUBLE',
+        room_count: 8,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      },
+      {
+        hotel_id: 2,
+        price: 8000,
+        room_type: 'DELUXE',
+        room_count: 5,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      },
+      {
+        hotel_id: 2,
+        price: 12000,
+        room_type: 'SUITE',
+        room_count: 2,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      },
+    ]);
+
+    await queryInterface.bulkInsert('rooms', [
+      {
+        id: 1,
+        hotel_id: 1,
+        room_category_id: 1,
+        date_of_availability: '2025-06-03',
+        room_no: 1,
+        booking_id: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      },
+      {
+        id: 2,
+        hotel_id: 1,
+        room_category_id: 2,
+        room_no: 1,
+        date_of_availability: '2025-06-04',
+        booking_id: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      },
+      {
+        id: 3,
+        hotel_id: 1,
+        room_category_id: 1,
+        room_no: 1,
+        date_of_availability: '2025-06-05',
+        booking_id: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      },
+      {
+        id: 4,
+        hotel_id: 2,
+        room_category_id: 3,
+        date_of_availability: '2025-06-03',
+        room_no: 1,
+        booking_id: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      },
+      {
+        id: 5,
+        hotel_id: 2,
+        room_category_id: 1,
+        room_no: 1,
+        date_of_availability: '2025-06-04',
+        booking_id: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      },
+      {
+        id: 6,
+        hotel_id: 2,
+        room_category_id: 2,
+        room_no: 1,
+        date_of_availability: '2025-06-05',
+        booking_id: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+        deleted_at: null,
+      },
+    ]);
+  },
+
+  async down(queryInterface: QueryInterface) {
+    await queryInterface.bulkDelete('rooms', {}, {});
+    await queryInterface.bulkDelete('hotels', {}, {});
+    await queryInterface.bulkDelete('room_categories', {}, {});
+  },
+};


### PR DESCRIPTION

This PR introduces the following schema migrations, associations, and seed data setup for the hotel booking system:

---

### 📦 Migrations

- **`rooms` table**  
  Includes:
  - `room_no`
  - `room_category_id`
  - `date_of_availability`
  - `price`
  - `booking_id`
  - Timestamps (`created_at`, `updated_at`, `deleted_at`)

- **`room_categories` table**  
  Includes:
  - `id`
  - `hotel_id`
  - `room_type` (ENUM: SINGLE, DOUBLE, FAMILY, DELUXE, SUITE)
  - `room_count`
  - `price`
  - Timestamps

---

### 🔗 Associations

- `rooms.room_category_id` ➝ `room_categories.id`  
  _(With `ON DELETE CASCADE`, `ON UPDATE CASCADE`)_

- `room_categories.hotel_id` ➝ `hotels.id`  
  _(With `ON DELETE CASCADE`, `ON UPDATE CASCADE`)_

---

### 🌱 Seed Data

A seed file is added for the all tables with dummy entries for different room types and hotels.  

---

### 🧪 Query Used for Room Availability

To fetch available rooms for a given category and date range (excluding already booked rooms), the following SQL query was used and validated:

```sql
SELECT COUNT(*) 
FROM room 
WHERE room_category_id = 1 
  AND date_of_availability BETWEEN '2025-06-03' AND '2025-06-05' 
  AND booking_id IS NULL 
GROUP BY room_no;
