### PR TITLE
migration for adding price-col in room table

### DIFF
--- a/HotelService/src/db/migrations/20250801174314-add-price-column-room-table.ts
+++ b/HotelService/src/db/migrations/20250801174314-add-price-column-room-table.ts
@@ -1,0 +1,19 @@
+"use strict";
+
+import { QueryInterface, Sequelize } from "sequelize";
+
+/** @type {import('sequelize-cli').Migration} */
+module.exports = {
+	async up(queryInterface: QueryInterface, Sequelize: Sequelize) {
+		await queryInterface.sequelize.query(
+			`ALTER TABLE rooms 
+            ADD COLUMN price INTEGER NOT NULL DEFAULT 10000;`
+		);
+	},
+
+	async down(queryInterface: QueryInterface, Sequelize: Sequelize) {
+		await queryInterface.sequelize.query(`
+            ALTER TABLE rooms 
+            DROP COLUMN price;`);
+	},
+};


### PR DESCRIPTION
`price` column has been added as part of this current PR in `rooms` table.
 `default price` is set to `10000`.

to migrate, run  
```
npm run migrate
```